### PR TITLE
feat: add tldr-pages corpus

### DIFF
--- a/corpus/tldr-pages/LICENSE
+++ b/corpus/tldr-pages/LICENSE
@@ -1,0 +1,6 @@
+Copyright © 2014—present the [tldr-pages team](https://github.com/orgs/tldr-pages/people)
+and [contributors](https://github.com/tldr-pages/tldr/graphs/contributors).
+
+**This work is licensed under the
+[Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/)
+(CC-BY).**

--- a/corpus/tldr-pages/Makefile
+++ b/corpus/tldr-pages/Makefile
@@ -1,0 +1,107 @@
+# -*-makefile-*-
+#
+# template for converting aligned parallel corpora
+# in TMX format (sentence aligned plain text) to OPUS
+#
+# - assumes that opus-tools are installed (moses2opus in PATH)
+#
+# BEFORE RUNNING:
+# - set corpus-specific info in Makefile.def
+# - change the include of preprocessing Makefiles if necessary
+#   (Makefile.tag for PoS tagging or Makefile.annotate)
+#
+
+include Makefile.def
+include ../Makefile.def
+
+## all TMX files in the src/ directory
+## we will convert them to Moses and use moses2opus as the second step
+
+TMXFILES   = ${shell find src -name '*.tmx'}
+TMXDONE    = ${TMXFILES:.tmx=_done}
+
+## make all:
+## - convert (see below)
+## - annotate (tokenize/tag/chunk depending on Makefile that is included)
+## - udparse (parse with UDPipe)
+## - publish (various packages, cwb index, website etc)
+## - wordalign
+
+.PHONY: all
+all:
+	${MAKE} fetch
+	${MAKE} import
+	${MAKE} publish
+
+.PHONY: fetch
+fetch:
+	mkdir -p src
+	wget -O src/tldr-pages.tar.gz https://tldr.sh/tldr-translation-pairs-gen/tldr-pages-translation-pairs.tar.gz
+	tar xf src/tldr-pages.tar.gz --directory src && rm src/tldr-pages.tar.gz
+	mv src/datasets/* src && rmdir src/datasets
+
+.PHONY: import
+import:
+	${MAKE} convert
+	${MAKE} -C xml create-align-files
+	${MAKE} annotate
+
+## standard procedures are specified in the following makefiles
+##
+##   Makefile.submit ....... submit a job to our cluster
+##   Makefile.process ...... standard corpus processing tasks
+##   Makfile.release ....... download packages and website
+##   Makefile.cwb .......... indexing with CWB
+##   Makfile.udparse ....... dependency parsing
+
+include ../Makefile.submit
+include ../Makefile.process
+include ../Makefile.release
+include ../Makefile.cwb
+include ../Makefile.udparse
+
+## select one of the following to set the annotation level in xml/
+##
+##   Makefile.tokenize ..... tokenization only
+##   Makefile.tag .......... tokenization and PoS tagging (if available)
+##   Makefile.annotate ..... all annotation in Uplug
+
+include ../Makefile.tokenize-polyglot
+# include ../Makefile.tokenize-fast
+# include ../Makefile.tokenize-moses
+# include ../Makefile.tokenize
+# include ../Makefile.tag
+# include ../Makefile.annotate
+
+## change this if tmx2opus is not in your PATH
+TMX2OPUS = tmx2opus
+
+BASIC_FILTERS = | perl -CS -pe 'tr[\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}][]cd;' \
+		| perl -CS -pe 's/\&\s*\#\s*160\s*\;/ /g' \
+		| perl -pe 's/[\p{C}-[\n\t]]/ /g;' \
+		| recode -f utf8..utf16 | recode -f utf16..utf8
+
+.PHONY: convert
+convert: ${TMXDONE}
+	${MAKE} xml/Makefile
+	-mv -f raw/*-* xml/
+
+## - do some basic tidying up to avoid problems
+## - use tidy only if the file is not too big
+##   tidy limit: 1GB compressed file size
+## - then convert to OPUS XML
+
+${TMXDONE}: %_done: %.tmx
+	mkdir -p raw
+	-if [ `stat -c%s $<` -ge 1073741824 ]; then \
+	  cat $< ${BASIC_FILTERS} > $<.tmp; \
+	else \
+	  cat $< ${BASIC_FILTERS} | tidy -xml -utf8 -q > $<.tmp; \
+	fi
+	if [ -s $<.tmp ]; then \
+	  cd raw && ${TMX2OPUS} -r -o ${notdir $(<:.tmx=.xml.gz)} ../$<.tmp; \
+	else \
+	  cd raw && ${TMX2OPUS} -r -o ${notdir $(<:.tmx=.xml.gz)} ../$<; \
+	fi
+	rm -f $<.tmp
+	touch $@

--- a/corpus/tldr-pages/Makefile.def
+++ b/corpus/tldr-pages/Makefile.def
@@ -1,0 +1,16 @@
+# -*-makefile-*-
+#
+# name & version of the corpus
+
+CORPUS  = tldr-pages
+VERSION = v2023-08-29
+
+LICENSE = CC-BY-4.0
+COPYRIGHT = tldr-pages team and contributors
+
+# with SRCHTML you can define some extra HTML code that will be placed just
+# after the name of the sub-corpus
+# EXTRAHTML is code which will be put just after the 'Download' header
+
+SRCHTML=<p>A parallel corpus of tldr-pages. Source: <a href="https://github.com/tldr-pages/tldr">https://github.com/tldr-pages/tldr</a></p>
+CONTACT = seth@falco.fun


### PR DESCRIPTION
This is based on the existing documentation and from reviewing your latest commits. This isn't perfect, I'd appreciate some pointers to get it right.

---

Adds a corpus for [tldr-pages](https://github.com/tldr-pages/tldr).

The TMX files are generated with [tldr-pages/tldr-translation-pairs-gen](https://github.com/tldr-pages/tldr-translation-pairs-gen), which I maintain as one of the members of the org.

The archive (updated once a month) is hosted on GitHub Pages and accessible from the following URLs:
* https://tldr.sh/tldr-translation-pairs-gen/tldr-pages-translation-pairs.tar.gz
* https://tldr-pages.github.io/tldr-translation-pairs-gen/tldr-pages-translation-pairs.tar.gz

The archive downloaded in `make fetch` looks like this when extracted:
https://gist.github.com/SethFalco/a53e431210c464426a918a9066e46366

Happy to accept advice if you think there is a more suitable way to store translations! The primary purpose of this is for OPUS, so advice can be tailored for this project too. 

There were numerous warnings while running `make all`, however, existing corpuses had the same thing, so I'm not sure which ones are real problems or not. :thinking: 

Regardless, `make all` does complete successfully, and generates release and info files. (I did not commit them, as I'm not actually making a release myself.)

Logs when I run `make all`:
https://gist.github.com/SethFalco/9769ad197607ff69a45c9f9e46b50742
