### PR TITLE
chore: add dependency on pybind11-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ UBUNTU_PACKAGES = libboost-all-dev \
 		parallel \
 		pigz \
 		python3-pip \
+		pybind11-dev \
 		tidy
 
 .PHONY: install


### PR DESCRIPTION
To install [opus-fast-mosestokenizer](https://pypi.org/project/opus-fast-mosestokenizer/) we need `pybind11-dev` which is in both the Debian and Ubuntu repositories. 

* https://packages.debian.org/bookworm/pybind11-dev
* https://packages.ubuntu.com/jammy/pybind11-dev

This just adds pybind11-dev to the `UBUNTU_PACKAGES` variable. Though, I have only tested this on Debian.

If this package is not installed on the system, then we get the following error when running `pip3 install -r requirements.txt`:

```
…
      CMake Error at CMakeLists.txt:154 (find_package):
        By not providing "Findpybind11.cmake" in CMAKE_MODULE_PATH this project has
        asked CMake to find a package configuration file provided by "pybind11",
        but CMake did not find one.
      
        Could not find a package configuration file provided by "pybind11" with any
        of the following names:
      
          pybind11Config.cmake
          pybind11-config.cmake
      
        Add the installation prefix of "pybind11" to CMAKE_PREFIX_PATH or set
        "pybind11_DIR" to a directory containing one of the above files.  If
        "pybind11" provides a separate development package or SDK, be sure it has
        been installed.
…
```